### PR TITLE
Fix the parsing of dates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GBIF"
 uuid = "ee291a33-5a6c-5552-a3c8-0f29a1181037"
 authors = ["Timothée Poisot <timothee.poisot@umontreal.ca>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/types/GBIFRecords.jl
+++ b/src/types/GBIFRecords.jl
@@ -46,7 +46,11 @@ function format_date(o, d)
     if t === nothing || ismissing(t)
         return missing
     else
-        return DateTime(t[1:19])
+        try
+            return DateTime(t[1:19])
+        catch
+            return missing
+        end
     end
 end
 


### PR DESCRIPTION
The date field *in GBIF* can be wrong, so if we can't parse it, we get a `missing`.

Closes #25 