### PR TITLE
Support for ranged pairs in queries

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,6 @@ jobs:
         version:
           - '1.3'
           - '1.4'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -9,9 +9,9 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-julia = "1.3"
 HTTP = "0.8"
 JSON = "0.21"
+julia = "1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -18,11 +18,11 @@ associated with observations of occurrences.
 occurrence
 ```
 
-This can be used to retrieve occurrence `1425976049`, with
+This can be used to retrieve occurrence `1258202889`, with
 
 ```@example
 using GBIF
-occurrence(1425976049)
+occurrence(1258202889)
 ```
 
 ### Multiple occurrences
@@ -41,7 +41,7 @@ For example, this allows writing the following:
 using GBIF
 o = occurrences()
 for single_occ in o
-  println(o.taxonKey)
+  println(single_occ)
 end
 ```
 

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -41,7 +41,7 @@ For example, this allows writing the following:
 using GBIF
 o = occurrences()
 for single_occ in o
-  println(single_occ)
+  print(single_occ)
 end
 ```
 
@@ -58,7 +58,9 @@ latitudes using the following syntax:
 ```@example
 using GBIF
 bats = GBIF.taxon("Chiroptera"; strict=false)
-occurrences(bats, "decimalLatitude" => (-30.0, 30.0))
+for oc in occurrences(bats, "decimalLatitude" => (-30.0, 30.0))
+  println("$(occ.taxon) -- latitude = $(occ.latitude)")
+end
 ```
 
 ### Batch-download of occurrences

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -37,12 +37,13 @@ occurrences recorded in GBIF. Note that the `GBIFRecords` type, returned by
 `occurrences`, implements all the necessary methods to iterate over collections.
 For example, this allows writing the following:
 
-~~~ julia
+```@example
+using GBIF
 o = occurrences()
 for single_occ in o
   println(o.taxonKey)
 end
-~~~
+```
 
 ### Query parameters
 
@@ -51,8 +52,23 @@ occurrences(query::Pair...)
 occurrences(t::GBIFTaxon, query::Pair...)
 ```
 
+For example, we can get the data on observations of bats between -30 and 30 of
+latitudes using the following syntax:
+
+```@example
+using GBIF
+bats = GBIF.taxon("Chiroptera"; strict=false)
+occurrences(bats, "latitude" => (-30.0, 30.0))
+```
+
 ### Batch-download of occurrences
 
 ```@docs
 occurrences!
+```
+
+```@example
+using GBIF
+can_most_recent = occurrences("hasCoordinate" => true, "country" => "CA")
+occurrences!(can_most_recent)
 ```

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -58,8 +58,8 @@ latitudes using the following syntax:
 ```@example
 using GBIF
 bats = GBIF.taxon("Chiroptera"; strict=false)
-for oc in occurrences(bats, "decimalLatitude" => (-30.0, 30.0))
-  println("$(occ.taxon) -- latitude = $(occ.latitude)")
+for occ in occurrences(bats, "decimalLatitude" => (-30.0, 30.0))
+  println("$(occ.scientific) -- latitude = $(occ.latitude)")
 end
 ```
 

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -58,7 +58,7 @@ latitudes using the following syntax:
 ```@example
 using GBIF
 bats = GBIF.taxon("Chiroptera"; strict=false)
-occurrences(bats, "latitude" => (-30.0, 30.0))
+occurrences(bats, "decimalLatitude" => (-30.0, 30.0))
 ```
 
 ### Batch-download of occurrences

--- a/docs/src/data.md
+++ b/docs/src/data.md
@@ -20,10 +20,10 @@ occurrence
 
 This can be used to retrieve occurrence `1425976049`, with
 
-~~~ julia
+```@example
 using GBIF
 occurrence(1425976049)
-~~~
+```
 
 ### Multiple occurrences
 

--- a/src/occurrence.jl
+++ b/src/occurrence.jl
@@ -5,7 +5,7 @@ function format_querypair_stem(stem::Tuple{T,T}) where {T <: Number}
 	if (M <= m )
 		throw(ArgumentError("Range queries must be formatted as min,max"))
 	end
-	return replace(string(m)*","*string(M), " " => %20)
+	return replace(string(m)*","*string(M), " " => "%20")
 end
 
 

--- a/src/query.jl
+++ b/src/query.jl
@@ -25,7 +25,9 @@ function validate_occurrence_query(query::Pair)
     "subGenusKey", "speciesKey", "year", "establishmentMeans", "repatriated",
     "typeStatus", "facet", "facetMincount", "facetMultiselect", "limit", "offset"]
 
-  @assert query.first ∈ allowed_fields
+  if !(query.first ∈ allowed_fields)
+    @error "The $(query.first) parameter is not allowed by the GBIF API"
+  end
 
   # Country must be a two-letters country code
   if query.first == "country"

--- a/src/taxon.jl
+++ b/src/taxon.jl
@@ -72,13 +72,20 @@ function taxon(name::String;
       # This will throw warnings for various reasons related to matchtypes
       matchtype = get(body, "matchType", "WELP...")
       # The first one will catch issues
-      matchtype == "WELP..." && throw(ErrorException("Impossible to get information for $(name) at level $(rank)"))
-      matchtype == "NONE" && throw(ErrorException("No match for $(name) at level $(rank) -- try with strict=false"))
+      if matchtype == "WELP..."
+         @warn "Impossible to get information for $(name) at level $(rank)"
+         return nothing
+      end
+      if matchtype == "NONE"
+         @warn "No match for $(name) at level $(rank) -- try with strict=false"
+         return nothing
+      end
       return GBIFTaxon(body)
    else
-      throw(ErrorException("Impossible to retrieve information for $(name) -- HTML error code $(sp_s_req.status)"))
+      @warn "Impossible to retrieve information for $(name) -- HTML error code $(sp_s_req.status)"
+      return nothing
    end
-
+   return nothing
 end
 
 """

--- a/src/taxon.jl
+++ b/src/taxon.jl
@@ -18,14 +18,15 @@ Optional arguments are
 
 - `strict::Bool=true` -- whether the match should be strict, or fuzzy
 
-- `verbose::Bool=false` -- whether the query should print out information about the reply (not usually useful)
-
 Finally, one can also specify other levels of the taxonomy, using  `kingdom`,
 `phylum`, `class`, `order`, `family`, and `genus`, all of which can either be
 `String` or `Nothing`.
+
+If a match is found, the result will be given as a `GBIFTaxon`. If not, this
+function will return `nothing` and give a warning.
 """
 function taxon(name::String;
-   rank::Union{Symbol,Nothing}=:SPECIES, strict::Bool=true, verbose::Bool=false,
+   rank::Union{Symbol,Nothing}=:SPECIES, strict::Bool=true,
    kingdom::Union{String,Nothing}=nothing, phylum::Union{String,Nothing}=nothing, class::Union{String,Nothing}=nothing,
    order::Union{String,Nothing}=nothing, family::Union{String,Nothing}=nothing, genus::Union{String,Nothing}=nothing)
    @assert rank ∈ [
@@ -35,7 +36,7 @@ function taxon(name::String;
       :SUBSPECIES, :SUBTRIBE, :SUBVARIETY, :SUPERCLASS , :SUPERFAMILY, :SUPERORDER,
       :SPECIES
    ]
-   args = Dict{String, Any}("name" => name, "strict" => strict, "verbose" => verbose)
+   args = Dict{String, Any}("name" => name, "strict" => strict)
 
    if rank != nothing
       args["rank"] = String(rank)

--- a/test/occurrences.jl
+++ b/test/occurrences.jl
@@ -14,7 +14,7 @@ module TestGBIFRecords
   @test length(set2) == 20
 
   # Version using ranged pairs
-  set3 = occurrences("scientificName" => "Mus musculus", "year" => 1999, "hasCoordinate" => true, "latitude" => (0.0,50.0))
+  set3 = occurrences("scientificName" => "Mus musculus", "year" => 1999, "hasCoordinate" => true, "decimalLatitude" => (0.0,50.0))
   @test typeof(set3) == GBIFRecords
   @test length(set3) == 20
 

--- a/test/occurrences.jl
+++ b/test/occurrences.jl
@@ -4,13 +4,18 @@ module TestGBIFRecords
   using Test
 
   # Version using pairs
-  set3 = occurrences("scientificName" => "Mus musculus", "year" => 1999, "hasCoordinate" => true)
-  @test typeof(set3) == GBIFRecords
-  @test length(set3) == 20
+  set1 = occurrences("scientificName" => "Mus musculus", "year" => 1999, "hasCoordinate" => true)
+  @test typeof(set1) == GBIFRecords
+  @test length(set1) == 20
 
   # Version with no query parameters
   set2 = occurrences()
   @test typeof(set2) == GBIFRecords
   @test length(set2) == 20
+
+  # Version using ranged pairs
+  set3 = occurrences("scientificName" => "Mus musculus", "year" => 1999, "hasCoordinate" => true, "latitude" => (0.0,50.0))
+  @test typeof(set3) == GBIFRecords
+  @test length(set3) == 20
 
 end


### PR DESCRIPTION
This offers a way to use ranged pairs for limits, for example `"latitude" => (-10.0, 10.0)`