### PR TITLE
Fix DataFrames dependency warning

### DIFF
--- a/src/requires/dataframes.jl
+++ b/src/requires/dataframes.jl
@@ -3,7 +3,7 @@
 format_gbif_entity(t::Missing) = missing
 format_gbif_entity(t::Pair{String,Int64}) = t.first
 
-import DataFrames: DataFrame
+import .DataFrames: DataFrame
 
 function DataFrames.DataFrame(records::GBIFRecords)
   output = DataFrame(


### PR DESCRIPTION
The `DataFrames` integration triggers a dependency warning when both packages are loaded:

```
julia> using DataFrames
julia> using GBIF
[ Info: Loading DataFrames support for GBIF.jl
┌ Warning: Package GBIF does not have DataFrames in its dependencies:
│ - If you have GBIF checked out for development and have
│   added DataFrames as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with GBIF
└ Loading DataFrames into GBIF from project dependency, future warnings for GBIF are suppressed.
```

I found the following in the [`Requires.jl` README](https://github.com/JuliaPackaging/Requires.jl). Adding the dot seems to fix the problem.

> In the `@require` block, or any included files, you can use or import the package, but note that you must use the syntax `using .Gadfly` or `import .Gadfly`, rather than the usual syntax. Otherwise you will get a warning about Gadfly not being in dependencies.
