### PR TITLE
add Base `read!` method to read all occurances to the array

### DIFF
--- a/src/types/iterators.jl
+++ b/src/types/iterators.jl
@@ -28,3 +28,11 @@ end
 function iterate(o::GBIFRecords, t::Union{Int64,Nothing})
     iterate(collect(view(o)), t)
 end
+
+function Base.read!(o::GBIFRecords)
+    # TODO: This is confusing synxtax, we should change it so length
+    # and size mean what they do in base Julia. 
+    while length(o) < size(o)
+        occurrences!(o)
+    end
+end

--- a/test/occurrences.jl
+++ b/test/occurrences.jl
@@ -33,4 +33,11 @@ while length(obs) < size(obs)
 end
 @test length(obs) == size(obs)
 
+# `read!` all of the available records
+toread = occurrences("scientificName" => "Burramys parvus", "limit" => 300)
+@test length(toread) == 300
+read!(toread)
+@test length(obs) == size(obs)
+
+
 end


### PR DESCRIPTION
Seems like it should be easier to just get all of the records? This is a very basic implementation. But `read!` seems like the most appropriate method to use.

From the docs for `read!`:
```
Read binary data from an I/O stream or file, filling in array.
```

It would be better if it was easy to change the "limit" keyword before doing this, setting it to `300`. See #47

Example: 
```julia
# Read the first occurrences
occ = occurrences("scienticName" => "Burramys parvus");
# get the rest
read!(occ)
```