### PR TITLE
plot heaadless with GR in docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,8 @@
 push!(LOAD_PATH, "../src/")
 
+# Run plotting headless
+ENV["GKSwstype"] = "100"
+
 using Documenter, GBIF
 
 makedocs(


### PR DESCRIPTION
This just fixes docs builds for all other PRs.

GR needs to run headless during CI where it doesn't have a graphical environment.