### PR TITLE
remove type pyracy

### DIFF
--- a/src/GBIF.jl
+++ b/src/GBIF.jl
@@ -85,15 +85,6 @@ const gbifenums = Dict(
   ]
  )
 
-#=
-HACK this is required because some GBIF strings fail to parse, and I do not know
-why.
-=#
-import Base: convert
-function convert(::Type{AbstractString}, t::T) where {T <: Nothing}
-  return "<nothing>"
-end
-
 # Load the main functions
 
 include("query.jl")


### PR DESCRIPTION
Retry #43 without the noise

Adding `convert(::Type[AbstractString}, ::Nothing`) is type piracy on core julia types. It affects every package loaded in a session and all of Base Julia.. The main issue being that it will allow code that calls `convert(String, nothing)` to work on a system with GBIF.jl loaded that will fail on another system without GBIF loaded, which is not the worst kind of piracy, but we still can't.

We should really find where nothing is being returned, and wrap it with check that inserts missing instead. Is there an example taxon that triggers the bug?

